### PR TITLE
Bug fix in reset procedure.

### DIFF
--- a/src/Esp32MQTTClient.cpp
+++ b/src/Esp32MQTTClient.cpp
@@ -606,6 +606,8 @@ void Esp32MQTTClient_Close(void)
         IoTHubClient_LL_Destroy(iotHubClientHandle);
         iotHubClientHandle = NULL;
     }
+
+    platform_deinit();
 }
 
 void Esp32MQTTClient_SetConnectionStatusCallback(CONNECTION_STATUS_CALLBACK connection_status_callback)


### PR DESCRIPTION
This is the pull request to fix #5 issue.

I Insert platform_deinit() call in Esp32MQTTClient_Close func.
As long as Esp32MQTTClient_Init func and Esp32MQTTClient_Close func are called proper manner, this edit works.
And ofcourse works when CheckConnection func is called for reset use.