### PR TITLE
Fix compiler error due to uninitialised request_id

### DIFF
--- a/src/az_iot/iothub_client/src/iothubtransport_mqtt_common.c
+++ b/src/az_iot/iothub_client/src/iothubtransport_mqtt_common.c
@@ -1033,7 +1033,7 @@ static void mqtt_notification_callback(MQTT_MESSAGE_HANDLE msgHandle, void* call
             IOTHUB_IDENTITY_TYPE type = retrieve_topic_type(topic_resp);
             if (type == IOTHUB_TYPE_DEVICE_TWIN)
             {
-                size_t request_id;
+                size_t request_id = 0;
                 int status_code;
                 bool notification_msg;
                 if (parse_device_twin_topic_info(topic_resp, &notification_msg, &request_id, &status_code) != 0)


### PR DESCRIPTION
`request_id` not being initialized causes a compiler error
(maybe-uninitialized) when compiling ESP32 in Release Mode
therefore breaking ESP32s Arduino Library.

ping @lirenhe - might be good to get this merged so we can
update the submodule in https://github.com/espressif/arduino-esp32