### PR TITLE
Fix  [issue #12](https://github.com/VSChina/ESP32_AzureIoT_Arduino/is…

### DIFF
--- a/src/az_iot/c-utility/pal/lwip/sntp_lwip.c
+++ b/src/az_iot/c-utility/pal/lwip/sntp_lwip.c
@@ -36,6 +36,7 @@ int SNTP_SetServerName(const char* serverName)
 int SNTP_Init()
 {
 	LogInfo("Initializing SNTP");
+	SNTP_Deinit();
 	sntp_setoperatingmode(SNTP_OPMODE_POLL);
 	sntp_init();
 	time_t ts = 0;


### PR DESCRIPTION
…sues/12) and [issue 18](https://github.com/VSChina/ESP32_AzureIoT_Arduino/issues/18)

```
assertion "Operating mode must not be set while SNTP client is running" failed: file "/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/lwip/lwip/src/apps/sntp/sntp.c", line 600, function: sntp_setoperatingmode
```    
`SNTP_Deinit();` required before `sntp_setoperatingmode(SNTP_OPMODE_POLL);` if SNTP was initialized already.