### PR TITLE
update method payload length

### DIFF
--- a/examples/GetStarted/GetStarted.ino
+++ b/examples/GetStarted/GetStarted.ino
@@ -92,7 +92,7 @@ static int  DeviceMethodCallback(const char *methodName, const unsigned char *pa
     result = 404;
   }
 
-  *response_size = strlen(responseMessage) + 1;
+  *response_size = strlen(responseMessage);
   *response = (unsigned char *)strdup(responseMessage);
 
   return result;


### PR DESCRIPTION
Leaving the `NULL` character included in the length causes errors with service side SDK's parsing the JSON.
Related: https://github.com/Azure/azure-iot-sdk-c/issues/1641 and https://github.com/Azure/azure-iot-sdk-node/issues/736